### PR TITLE
Update the docs according to latest Laravel.

### DIFF
--- a/docker/base
+++ b/docker/base
@@ -102,12 +102,12 @@ RUN for l in "fr_CH" "de_CH" "it_CH" "en_US"; \
 
 
 ## NGINX
+# auto worker processes and no daemonize (for runit)
+# logs to user directory
 RUN f=/etc/nginx/nginx.conf \
  && rm /etc/nginx/sites-enabled/default \
  && rm -rf /var/www/html \
-    # auto worker processes and no daemonize (for runit)
  && sed -i 's/\(worker_processes\) .*;/\1 auto;\ndaemon off;/' $f \
-    # logs to user directory
  && sed -i 's/\/var\/log\/nginx\/access.log/\/var\/www\/logs\/nginx_access.log/' $f \
  && sed -i 's/\/var\/log\/nginx\/error.log/\/var\/www\/logs\/nginx_error.log/' $f
 

--- a/docker/laravel
+++ b/docker/laravel
@@ -11,15 +11,12 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E5267A6C \
  && apt-get upgrade -q -y --allow-unauthenticated \
  && apt-get install -q -y --allow-unauthenticated \
         composer \
-        php-apcu \
         php${PHP_VERSION}-bz2 \
         php${PHP_VERSION}-cli \
         php${PHP_VERSION}-curl \
         php${PHP_VERSION}-intl \
         php${PHP_VERSION}-fpm \
         php${PHP_VERSION}-gd \
-        php-libsodium \
-        php-imagick \
         php${PHP_VERSION}-imap \
         php${PHP_VERSION}-mbstring \
         php${PHP_VERSION}-mysql \
@@ -31,6 +28,9 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E5267A6C \
         php${PHP_VERSION}-xmlrpc \
         php${PHP_VERSION}-xsl \
         php${PHP_VERSION}-zip \
+        php-apcu \
+        php-sodium \
+        php-imagick \
         php-redis \
         php-xdebug \
  && apt-get autoremove \

--- a/files/laravel/README.md
+++ b/files/laravel/README.md
@@ -22,7 +22,7 @@ $ composer global require laravel/installer=~1.3
 
 # Laravel tutorial
 
-This is from the [Laravel 5.3 documentation](http://laravel.com/docs/5.3).
+This is from the [Laravel 5.5 documentation](http://laravel.com/docs/5.5).
 
 ## Creating a new project
 
@@ -110,14 +110,7 @@ In Postgres, it's similar expect that this is done with three schemas within one
 
 # Initializing the models
 
-The models are defined through [migrations](http://laravel.com/docs/5.1/migrations) which enable rollbacks. You should always use them. We will instantiate the default model which creates two tables do deal with users and their password.
-
-The default model was set for utf8 and not utf8mb4, so we have to tweak it a little bit. Open `blog/database/migrations/2014_10_12_000000_create_users_table.php`
-
-```
-//$table->string('email')->unique();
-$table->string('email', 191)->unique();
-```
+The models are defined through [migrations](http://laravel.com/docs/5.5/migrations) which enable rollbacks. You should always use them. We will instantiate the default model which creates two tables do deal with users and their password.
 
 Now, we are ready to run the migrations:
 
@@ -141,12 +134,12 @@ users
 
 # JavaScript and CSS
 
-Laravel comes with some default libraries like Bootstrap. To rebuild them, do the following commands:
+Laravel comes with some default libraries like Bootstrap and Vue.js. To rebuild them, do the following commands:
 
 ```
 $ npm install
-$ gulp
-$ gulp --production
+$ npm run dev # or development
+$ npm run prod # or production
 ```
 
 Although, doing this on the production server is not a good idea. Putting the generated scripts and stylesheets on Git is ok.


### PR DESCRIPTION
- liens pour la doc
- le problème du 191 n'est plus si on utilise MySQL 5.7.7 ou MariaDB 10.2.2
- libsodium est devenu sodium (inclu dans PHP 7.2)
- `gulp` vs `npm run`

Signed-off-by: Yoan Blanc <yoan@dosimple.ch>