### PR TITLE
Force artful image.

### DIFF
--- a/docker/base
+++ b/docker/base
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu:artful
 
 ARG MYSQL_VERSION
 ARG NODEJS_VERSION


### PR DESCRIPTION
Maintenant que `artful` est officiel, on peut fixer la version et éviter de basculer dans la suivante avec `rolling`.