### PR TITLE
Force zesty image.

### DIFF
--- a/docker/base
+++ b/docker/base
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu:zesty
 
 ARG MYSQL_VERSION
 ARG NODEJS_VERSION


### PR DESCRIPTION
En fait, c'était bien `zesty`. N'hésite pas à tester avec `artful`. Sauf erreur, ça coinçait avec Postgres, mais ce n'est peut-être plus le cas.

![](https://screenshots.firefoxusercontent.com/images/130c537e-28ca-4543-ad37-f09c453f4666.png)

https://microbadger.com/images/hearcch/webapp-server