### PR TITLE
Update Traefik V2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,11 @@ services:
     domainname: srvz-webapp.he-arc.ch
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./traefik.toml:/etc/traefik/traefik.toml
-      - proxy:/etc/traefik/acme
+      - ./traefik:/etc/traefik/
     ports:
       - "8080:8080"
       - "80:80"
       - "443:443"
-    command: -c /etc/traefik/traefik.toml --docker.domain=localhost --api.debug
 
   portainer:
     image: portainer/portainer:1.20.1

--- a/examples/laravel.yml
+++ b/examples/laravel.yml
@@ -19,7 +19,11 @@ services:
     links:
       - eatapp_redis:redis
     labels:
-      - "traefik.http.routers.web.rule=Host(`eatapp.srvz-webapp.he-arc.ch`)"
+      - "traefik.enable=true"
+      - "traefik.http.services.eatapp.loadbalancer.server.port=80"
+      - "traefik.http.routers.eatapp.rule=Host(`eatapp.srvz-webapp.he-arc.ch`)"
+      - "traefik.http.routers.eatapp.entrypoints=web-secure"
+      - "traefik.http.routers.eatapp.tls.certresolver=letsencrypt"
 
   eatapp_redis:
     image: redis:5-alpine
@@ -27,9 +31,8 @@ services:
       - eatapp_redis:/data
 
 networks:
-  default:
-    external:
-      name: webapp-net
+  web:
+    external: true
 
 volumes:
   eatapp:

--- a/traefik/dynamic_conf.toml
+++ b/traefik/dynamic_conf.toml
@@ -1,0 +1,18 @@
+#Dummy service router to redirect everything to HTTPS globally
+[http.routers]
+  [http.routers.redirecttohttps]
+    entryPoints = ["web"]
+    middlewares = ["httpsredirect"]
+    rule = "HostRegexp(`{host:.+}`)"
+    service = "noop"
+
+[http.services]
+  # noop service, the URL will be never called (dummy router)
+  [http.services.noop.loadBalancer]
+    [[http.services.noop.loadBalancer.servers]]
+      url = "http://192.168.200.1"
+
+[http.middlewares]
+  [http.middlewares.httpsredirect.redirectScheme]
+    scheme = "https"
+

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -28,7 +28,7 @@ defaultEntryPoints = ["web", "web-secure"]
   address = ":8080"
 
 
-[certificatesResolvers.sample.acme]
+[certificatesResolvers.letsencrypt.acme]
   email = "yoan.blanc@he-arc.ch"
   storage = "/etc/traefik/acme.json"
 [certificatesResolvers.letsencrypt.acme.httpChallenge]

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -1,0 +1,36 @@
+defaultEntryPoints = ["web", "web-secure"]
+
+[log]
+  level = "DEBUG"
+  filePath = "/proc/self/fd/1"
+  format = "json"
+
+[api]
+  dashboard = true
+  insecure = true
+
+[providers.docker]
+  watch = true
+  exposedByDefault = false
+  network = "web"
+
+[providers.file]
+  filename = "/etc/traefik/dynamic_conf.toml"
+  watch = true
+
+[entryPoints]
+  [entryPoints.web]
+    address = ":80"
+  [entryPoints.web-secure]
+    address = ":443"
+
+[entryPoints.traefik]
+  address = ":8080"
+
+
+[certificatesResolvers.sample.acme]
+  email = "yoan.blanc@he-arc.ch"
+  storage = "/etc/traefik/acme.json"
+[certificatesResolvers.letsencrypt.acme.httpChallenge]
+    entryPoint = "web"
+


### PR DESCRIPTION
This is meant to close #70 

Updated config for Traefik V2. The main problem was that Traefik was using the port 22 as declared in your EXPOSE attribute in your Dockerfile. We had to tell Traefik explicitly that it should use port 80.

Since I was modifying your configuration, I also improved your configuration for automatic HTTPS redirection, custom rules in a dynamic file and improved your certificates storage.

Each service meant to be proxied by Traefik should be inside the "web" network. Do not forget to create it with : docker network create web

Each docker-compose should have : 
```
networks:
  web:
    external: true
```
at the bottom, and each service that should be proxied need to have the following network attribute:
```
networks:
  - web
```

