### PR TITLE
fix: laravel image PHP_VERSION was hardcoded

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -11,10 +11,10 @@ services:
       context: .
       # Set VCS/BUILD manually or use the Makefile.
       args:
-        VCS_REF: $VCS_REF
-        BUILD_DATE: $BUILD_DATE
-        NODEJS_VERSION: "14.x"
-        UBUNTU_VERSION: focal
+        - VCS_REF=$VCS_REF
+        - BUILD_DATE=$BUILD_DATE
+        - NODEJS_VERSION=14.x
+        - UBUNTU_VERSION=focal
 
   laravel:
     image: hearcch/webapp-server:laravel
@@ -24,6 +24,7 @@ services:
       args:
         - VCS_REF=$VCS_REF
         - BUILD_DATE=$BUILD_DATE
+        - PHP_VERSION=7.4
 
   rails:
     image: hearcch/webapp-server:rails

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,12 +16,13 @@ services:
     command: -c /etc/traefik/traefik.toml --docker.domain=srvz-webapp.he-arc.ch
 
   portainer:
-    image: portainer/portainer:1.24.1
+    image: portainer/portainer-ce:2.1.1-alpine
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - portainer:/data
     # private
     ports:
+      #- "8000:8000"  # TCP tunnel
       - "9000:9000"
     # public
     #labels:

--- a/docker/laravel
+++ b/docker/laravel
@@ -63,6 +63,7 @@ COPY files/laravel /var/templates/laravel
 
 # Config
 ENV CONFIG laravel
+ENV PHP_VERSION=${PHP_VERSION}
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/examples/base.yml
+++ b/examples/base.yml
@@ -22,7 +22,7 @@ services:
       - "traefik.enable=true"
 
   admin_redis:
-    image: redis:5-alpine
+    image: redis:6-alpine
     volumes:
       - admin_redis:/data
 

--- a/examples/laravel.yml
+++ b/examples/laravel.yml
@@ -24,7 +24,7 @@ services:
       - "traefik.enable=true"
 
   eatapp_redis:
-    image: redis:5-alpine
+    image: redis:6-alpine
     volumes:
       - eatapp_redis:/data
 

--- a/examples/python.yml
+++ b/examples/python.yml
@@ -22,7 +22,7 @@ services:
       - "traefik.enable=true"
 
   weblog_redis:
-    image: redis:5-alpine
+    image: redis:6-alpine
     volumes:
       - weblog_redis:/data
 

--- a/examples/rails.yml
+++ b/examples/rails.yml
@@ -24,7 +24,7 @@ services:
       - "traefik.enable=true"
 
   capistrano_redis:
-    image: redis:4-alpine
+    image: redis:6-alpine
     volumes:
       - capistrano_redis:/data
 

--- a/files/laravel/boot.sh
+++ b/files/laravel/boot.sh
@@ -8,8 +8,8 @@ cp /var/templates/laravel/README.md /var/www/
 [ ! -f /var/www/app ] && cp -r /var/templates/laravel/app /var/www/app
 
 
-if [ ! -L /etc/php/7.2/fpm/pool.d/www.conf ]
+if [ ! -L /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf ]
 then
-    sudo mv /etc/php/7.2/fpm/pool.d/www.conf /etc/php/7.2/fpm/pool.d/www.conf.old
-    sudo ln -s /var/www/config/php-fpm.conf /etc/php/7.2/fpm/pool.d/www.conf
+    sudo mv /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf.old
+    sudo ln -s /var/www/config/php-fpm.conf /etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
 fi


### PR DESCRIPTION
the PHP_VERSION was hardcoded in the Laravel image... hence it didn't start properly.

**Upgrades**

- redis 5 -> 6
- portainer 1.24 -> 2.1